### PR TITLE
ui: replace icon-only toolbar buttons with Label

### DIFF
--- a/Mercury/Mercury/Reader/Views/ReaderDetailView+Toolbar.swift
+++ b/Mercury/Mercury/Reader/Views/ReaderDetailView+Toolbar.swift
@@ -29,18 +29,16 @@ extension ReaderDetailView {
                     Button {
                         translationToggleRequested = true
                     } label: {
-                        Image(systemName: translationToggleButtonIconName)
+                        Label(translationToggleButtonText, systemImage: translationToggleButtonIconName)
                     }
-                    .accessibilityLabel(Text(translationToggleButtonText))
                     .help(translationToggleButtonText)
 
                     Button {
                         translationClearRequested = true
                     } label: {
-                        Image(systemName: "eraser")
+                        Label(String(localized: "Clear Translation", bundle: bundle), systemImage: "eraser")
                     }
                     .disabled(hasPersistedTranslationForCurrentSlot == false)
-                    .accessibilityLabel(Text("Clear Translation", bundle: bundle))
                     .help(String(localized: "Clear saved translation for current language", bundle: bundle))
                 }
             }
@@ -49,8 +47,7 @@ extension ReaderDetailView {
                 Button {
                     isTagPanelPresented.toggle()
                 } label: {
-                    Text("#")
-                        .font(.system(size: 15, weight: .semibold, design: .rounded))
+                    Label(String(localized: "Tags", bundle: bundle), systemImage: "number")
                 }
                 .help(String(localized: isTagPanelPresented ? "Close tags panel" : "Open tags panel", bundle: bundle))
 
@@ -67,7 +64,7 @@ extension ReaderDetailView {
                 Button {
                     onOpenDebugIssues()
                 } label: {
-                    Image(systemName: "ladybug")
+                    Label(String(localized: "Debug", bundle: bundle), systemImage: "ladybug")
                 }
                 .help(String(localized: "Open debug issues", bundle: bundle))
             }
@@ -90,9 +87,9 @@ extension ReaderDetailView {
         Button {
             isThemePanelPresented.toggle()
         } label: {
-            Image(systemName: "paintpalette")
+            Label(String(localized: "Theme", bundle: bundle), systemImage: "paintpalette")
         }
-        .help(isThemePanelPresented ? "Close theme panel" : "Open theme panel")
+        .help(String(localized: isThemePanelPresented ? "Close theme panel" : "Open theme panel", bundle: bundle))
     }
 
     func shareToolbarMenu(url: URL, urlString: String) -> some View {
@@ -105,7 +102,7 @@ extension ReaderDetailView {
                 NSWorkspace.shared.open(url)
             }) { Text("Open in Default Browser", bundle: bundle) }
         } label: {
-            Image(systemName: "square.and.arrow.up")
+            Label(String(localized: "Share", bundle: bundle), systemImage: "square.and.arrow.up")
         }
         .menuIndicator(.hidden)
         .help(String(localized: "Share", bundle: bundle))


### PR DESCRIPTION
### Description

This PR replaces several icon-only Button labels in the reader toolbar with Label views that include both text and system images.

### Changes

Replace Image(systemName:) with Label(_, systemImage:) for toolbar buttons:

Translation toggle
Clear translation
Tags
Debug
Theme
Share

Remove redundant .accessibilityLabel modifiers where Label already provides text.
Localize newly introduced visible labels.
Ensure .help strings use bundle for localization where applicable.
Replace the "#" tag button with a labeled Tags button for clarity.


### Screenshots

Before:

<img width="736" height="403" alt="image" src="https://github.com/user-attachments/assets/49042d33-3712-49f4-97a2-8a9319c90c3b" />

<img width="665" height="187" alt="image" src="https://github.com/user-attachments/assets/72ad31d6-5256-4464-ad93-41dfb0e998b7" />

After:

<img width="778" height="355" alt="image" src="https://github.com/user-attachments/assets/aa3ddb55-adb2-4b7f-950e-0481e976d8e3" />

<img width="552" height="208" alt="image" src="https://github.com/user-attachments/assets/c1814723-9858-4600-9ec4-a18bc6ea7c8b" />

